### PR TITLE
Render negative integers correctly (#1)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -446,7 +446,7 @@
                 if (!inp || inp === '+/–') {
                     tmp[1] = (((+('1.' + tmp[1])).toPrecision(bigger ? 9 : tmp[2][1] ? 7 : 9)) + '');
                     if (tmp[1] >= 2) {
-                        tmp[0] = (+tmp[0] + 1) + '';
+                        tmp[0] = (+tmp[0] + (+val >= 0) ? 1 : -1) + '';
                     }
                     tmp[1] = tmp[1].substr(2).replace(/0+$/, '');
                 }


### PR DESCRIPTION
This commit addresses an issue where negative numbers ending in at least nine 9's displayed 2 greater than they should.